### PR TITLE
feat: pre-bind port validation and post-start self-test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 All notable changes to Squeezr will be documented here.
 
+## [Unreleased]
+### Added
+- **Port-conflict diagnostics** — On startup, Squeezr now classifies the configured port as `free`, `squeezr` (existing instance), or `foreign` (an unrelated HTTP service). When a foreign service is detected (e.g. a Docker container squatting on 8080), Squeezr prints an explicit warning that names the conflict and reminds the user that their shell env vars likely still point to the wrong port. This prevents Claude Code from silently routing API calls into Apache/WordPress/etc., which produced cryptic errors like `undefined is not an object (evaluating '$.speed')`.
+- **Post-start self-test** — After a successful `listen()`, Squeezr runs four async checks that never block accepting requests:
+  - `loopback_health` — verifies the bound port answers `/squeezr/health` with the expected `identity`/`version`.
+  - `env_coherence` — checks that `ANTHROPIC_BASE_URL`, `openai_base_url` and `GEMINI_API_BASE_URL` actually point to the bound port; if they drifted (because `findFreePort` picked a different port than the one in `squeezr.toml`), it prints the exact `export` lines to fix it.
+  - `upstream_reachable` — DNS + TLS handshake to `api.anthropic.com` (no payload, no quota cost).
+  - `pipeline_dryrun` — sends a minimal Anthropic-format request with the new `X-Squeezr-DryRun: 1` header, exercising the full compression path without forwarding to upstream.
+  - Results are exposed at `GET /squeezr/selftest` and printed at startup.
+- **Health endpoint identity field** — `GET /squeezr/health` now includes `"identity": "squeezr"`, so external callers (shell wrappers, auto-heal scripts, CI checks) can distinguish a real Squeezr instance from any other HTTP service that happens to answer 200.
+- **Runtime info file** — Squeezr writes its actual bound port + PID to `~/.squeezr/runtime.json` on startup and clears it on shutdown. The shell wrapper and `squeezr status` read this file so they always know the real port, even when `findFreePort` drifted.
+
+### Fixed
+- **Auto-heal in `setupUnix` / `setupWSL` / `squeezr ports`** — The shell-profile auto-heal previously used `curl -sf …/squeezr/health`, which does not fail on 3xx responses. A foreign service replying with `301` (e.g. WordPress redirecting `/squeezr/health` → `/squeezr/health/`) was therefore mistaken for a healthy Squeezr, and the auto-heal never restarted the proxy. The block now uses an `_squeezr_alive` helper that grep-matches `"identity":"squeezr"` in the body.
+- **`squeezr start` version detection** — `startDaemon()` previously caught a `JSON.parse('')` error, returned the string `'unknown'`, and entered a "version mismatch → restart" loop against the foreign service. It now uses the same `identity` validation, so a foreign service is correctly reported instead of triggering a restart attempt that cannot succeed.
+- **`squeezr status`** — When the configured port is occupied by a foreign service, the command now reports it explicitly (with the foreign `Server` header) instead of saying "Squeezr is NOT running".
+
 ## [1.22.0] - 2026-04-10
 ### Added
 - **Resilience: Circuit breaker for AI compression** — After 3 consecutive AI compression failures (Haiku/GPT-4o-mini/Gemini Flash), Squeezr automatically skips AI compression for 60s, then probes recovery. Prevents hammering a down backend. State visible in dashboard, MCP `squeezr_status`, and `squeezr status` CLI.

--- a/README.md
+++ b/README.md
@@ -284,6 +284,30 @@ Squeezr uses cheap/free models for AI compression (the deterministic layer is pu
 - For Codex MITM: set `HTTPS_PROXY=http://localhost:8081` in the terminal where you run Codex (not set globally to avoid interfering with other tools)
 - For local compression: [Ollama](https://ollama.ai) with `qwen2.5-coder:1.5b`
 
+## Troubleshooting
+
+### Claude Code throws `undefined is not an object (evaluating '$.speed')`
+
+Symptom: every prompt in Claude Code immediately errors with `undefined is not an object (evaluating '$.speed')` (or similar `$.X` parse errors). This means Claude Code is sending its API requests to **something that is not Squeezr** but happens to occupy Squeezr's port — typically a Docker container (Apache, nginx, WordPress) bound to `8080`.
+
+To diagnose, run:
+
+```bash
+squeezr status
+```
+
+If the output says `a foreign service is` listening on the port, you have three options:
+
+1. **Move Squeezr to a different port** (recommended): `squeezr ports` and pick something free, then reopen your terminal.
+2. **Stop the offending service**: `docker ps` to find what owns 8080, then `docker stop <id>`.
+3. **Inspect runtime info**: `cat ~/.squeezr/runtime.json` shows the *actual* port Squeezr is bound to. If it differs from your `ANTHROPIC_BASE_URL`, run `squeezr setup` to refresh your shell profile.
+
+Squeezr v1.23.0+ runs a self-test on every startup that detects this exact failure mode and prints actionable hints. You can re-run it any time with:
+
+```bash
+curl -s "http://localhost:$(jq -r .port ~/.squeezr/runtime.json)/squeezr/selftest?run=1" | jq
+```
+
 ## License
 
 MIT

--- a/bin/squeezr.js
+++ b/bin/squeezr.js
@@ -74,9 +74,20 @@ function getPortFromToml() {
   return null
 }
 
+// Runtime info written by src/index.ts after a successful listen(). Reflects
+// the *actual* bound port, which may differ from squeezr.toml when findFreePort
+// drifted because the configured port was occupied.
+const RUNTIME_FILE = path.join(os.homedir(), '.squeezr', 'runtime.json')
+
+function readRuntimeInfo() {
+  try { return JSON.parse(fs.readFileSync(RUNTIME_FILE, 'utf-8')) } catch { return null }
+}
+
 function getMitmPort(port) {
   const envMitm = process.env.SQUEEZR_MITM_PORT
   if (envMitm) return parseInt(envMitm)
+  const runtime = readRuntimeInfo()
+  if (runtime && runtime.mitmPort) return runtime.mitmPort
   try {
     const toml = fs.readFileSync(path.join(ROOT, 'squeezr.toml'), 'utf-8')
     const m = toml.match(/^mitm_port\s*=\s*(\d+)/m)
@@ -86,7 +97,35 @@ function getMitmPort(port) {
 }
 
 function getPort() {
-  return process.env.SQUEEZR_PORT || getPortFromToml() || 8080
+  if (process.env.SQUEEZR_PORT) return parseInt(process.env.SQUEEZR_PORT)
+  const runtime = readRuntimeInfo()
+  if (runtime && runtime.port) return runtime.port
+  return getPortFromToml() || 8080
+}
+
+/**
+ * Verifies that whatever is listening on `port` is actually a squeezr instance
+ * (by checking the magic `identity` field in /squeezr/health), not an unrelated
+ * HTTP service that happens to answer 200. Returns the parsed health JSON, or
+ * null if the port is free, unreachable, or owned by a foreign service.
+ */
+function probeSqueezr(port, timeoutMs = 1500) {
+  return new Promise(resolve => {
+    const req = http.get({ host: '127.0.0.1', port, path: '/squeezr/health' }, res => {
+      let data = ''
+      res.on('data', chunk => { data += chunk })
+      res.on('end', () => {
+        if (res.statusCode !== 200) return resolve(null)
+        try {
+          const json = JSON.parse(data)
+          if (json && json.identity === 'squeezr') return resolve(json)
+        } catch {}
+        resolve(null)
+      })
+    })
+    req.on('error', () => resolve(null))
+    req.setTimeout(timeoutMs, () => { req.destroy(); resolve(null) })
+  })
 }
 
 /**
@@ -232,19 +271,12 @@ async function startDaemon() {
     process.exit(1)
   }
 
-  // Check if already running — and if the version matches
+  // Check if already running — and if the version matches. We use probeSqueezr
+  // (which validates the `identity` field) so we don't mistake an unrelated
+  // HTTP service squatting on this port for a real squeezr instance.
   const port = getPort()
-  const runningVersion = await new Promise(resolve => {
-    const req = http.get(`http://localhost:${port}/squeezr/health`, res => {
-      let data = ''
-      res.on('data', chunk => { data += chunk })
-      res.on('end', () => {
-        try { resolve(JSON.parse(data).version) } catch { resolve('unknown') }
-      })
-    })
-    req.on('error', () => resolve(null))
-    req.setTimeout(2000, () => { req.destroy(); resolve(null) })
-  })
+  const running = await probeSqueezr(port)
+  const runningVersion = running ? running.version : null
   if (runningVersion) {
     if (runningVersion === pkg.version) {
       const mitmPort = getMitmPort(port)
@@ -375,45 +407,45 @@ function stopProxy() {
 async function checkStatus() {
   const port = getPort()
   const mitmPort = getMitmPort(port)
-  return new Promise(resolve => {
-    const req = http.get(`http://localhost:${port}/squeezr/health`, res => {
-      let data = ''
-      res.on('data', chunk => { data += chunk })
-      res.on('end', () => {
-        try {
-          const json = JSON.parse(data)
-          console.log(`Squeezr is running  (v${json.version})`)
-          console.log(`  HTTP proxy (Claude/Aider/Gemini): http://localhost:${port}`)
-          console.log(`  MITM proxy (Codex):               http://localhost:${mitmPort}`)
-          console.log(`  Dashboard:                        http://localhost:${port}/squeezr/dashboard`)
-          if (json.mode) console.log(`  Mode:     ${json.mode}`)
-          if (json.uptime_seconds != null) {
-            const s = json.uptime_seconds
-            const fmt = s < 60 ? `${s}s` : s < 3600 ? `${Math.floor(s/60)}m ${s%60}s` : `${Math.floor(s/3600)}h ${Math.floor((s%3600)/60)}m`
-            console.log(`  Uptime:   ${fmt}`)
-          }
-          if (json.bypassed) console.log(`  ⚠ Bypass mode is ON (compression disabled)`)
-          if (json.circuit_breaker) {
-            const cb = json.circuit_breaker
-            const icons = { closed: '🟢 OK', open: '🔴 OPEN', 'half-open': '🟡 PROBING' }
-            console.log(`  Circuit:  ${icons[cb.state] || cb.state}${cb.total_trips ? ` (${cb.total_trips} trip${cb.total_trips > 1 ? 's' : ''})` : ''}`)
-          }
-        } catch {
-          console.log(`Squeezr is running on port ${port}`)
-        }
-        resolve(true)
+  const json = await probeSqueezr(port, 2000)
+  if (!json) {
+    // Distinguish "nothing here" from "something foreign here" so the user gets
+    // an actionable error instead of a misleading "not running".
+    const occupied = await new Promise(resolve => {
+      const req = http.get(`http://localhost:${port}/`, res => {
+        resolve({ status: res.statusCode, server: res.headers.server })
+        res.resume()
       })
+      req.on('error', () => resolve(null))
+      req.setTimeout(1500, () => { req.destroy(); resolve(null) })
     })
-    req.on('error', () => {
+    if (occupied) {
+      console.log(`Squeezr is NOT running on port ${port}, but a foreign service is.`)
+      console.log(`  Foreign response: HTTP ${occupied.status}${occupied.server ? ` (Server: ${occupied.server})` : ''}`)
+      console.log(`  Stop it or change squeezr.toml port, then run: squeezr start`)
+    } else {
       console.log(`Squeezr is NOT running`)
       console.log('Start it with: squeezr start')
-      resolve(false)
-    })
-    req.setTimeout(2000, () => {
-      req.destroy()
-      resolve(false)
-    })
-  })
+    }
+    return false
+  }
+  console.log(`Squeezr is running  (v${json.version})`)
+  console.log(`  HTTP proxy (Claude/Aider/Gemini): http://localhost:${port}`)
+  console.log(`  MITM proxy (Codex):               http://localhost:${mitmPort}`)
+  console.log(`  Dashboard:                        http://localhost:${port}/squeezr/dashboard`)
+  if (json.mode) console.log(`  Mode:     ${json.mode}`)
+  if (json.uptime_seconds != null) {
+    const s = json.uptime_seconds
+    const fmt = s < 60 ? `${s}s` : s < 3600 ? `${Math.floor(s/60)}m ${s%60}s` : `${Math.floor(s/3600)}h ${Math.floor((s%3600)/60)}m`
+    console.log(`  Uptime:   ${fmt}`)
+  }
+  if (json.bypassed) console.log(`  ⚠ Bypass mode is ON (compression disabled)`)
+  if (json.circuit_breaker) {
+    const cb = json.circuit_breaker
+    const icons = { closed: '🟢 OK', open: '🔴 OPEN', 'half-open': '🟡 PROBING' }
+    console.log(`  Circuit:  ${icons[cb.state] || cb.state}${cb.total_trips ? ` (${cb.total_trips} trip${cb.total_trips > 1 ? 's' : ''})` : ''}`)
+  }
+  return true
 }
 
 function showConfig() {
@@ -605,8 +637,8 @@ async function configurePorts() {
         if (content.includes('# squeezr env vars')) {
           // Replace existing block (from marker to the closing fi)
           content = content.replace(
-            /# squeezr env vars[\s\S]*?fi/,
-            `# squeezr env vars\n${envBlock}\n# squeezr auto-heal\nif ! curl -sf http://localhost:${finalPort}/squeezr/health > /dev/null 2>&1; then squeezr start > /dev/null 2>&1; fi`
+            /# squeezr env vars[\s\S]*?(?:fi|unset -f _squeezr_alive)/,
+            `# squeezr env vars\n${envBlock}\n# squeezr auto-heal (validates identity, not just HTTP 200)\n_squeezr_alive() {\n  curl -sf --max-time 2 "http://localhost:${finalPort}/squeezr/health" 2>/dev/null | grep -q '"identity":"squeezr"'\n}\nif ! _squeezr_alive; then squeezr start > /dev/null 2>&1; fi\nunset -f _squeezr_alive`
           )
           fs.writeFileSync(p, content)
           console.log(`  [ok] Updated ${p}`)
@@ -973,6 +1005,13 @@ function setupUnix() {
   const port = getPort()
   const mitmPort = getMitmPort(port)
   const bundlePath = path.join(os.homedir(), '.squeezr', 'mitm-ca', 'bundle.crt')
+  // The auto-heal validates that whatever answers on the configured port is
+  // actually squeezr (by checking the magic `identity` field). A bare
+  // `curl -sf .../squeezr/health` is NOT enough because curl returns success on
+  // 3xx redirects, so a foreign service (e.g. an Apache+WordPress container on
+  // 8080) would be mistaken for a healthy squeezr — and Claude Code would then
+  // route its API requests into the wrong service, producing cryptic errors
+  // like `undefined is not an object (evaluating '$.speed')`.
   const shellBlock = [
     `# squeezr env vars`,
     `export ANTHROPIC_BASE_URL=http://localhost:${port}`,
@@ -982,11 +1021,15 @@ function setupUnix() {
     `# NOTE: HTTPS_PROXY is intentionally NOT set globally — it would route ALL HTTPS`,
     `# (including Claude Code) through the MITM proxy and cause 502 errors.`,
     `# For Codex, set it per-session only: HTTPS_PROXY=http://localhost:${mitmPort} codex`,
-    `# squeezr auto-heal: start proxy if not running`,
-    `if ! curl -sf http://localhost:${port}/squeezr/health >/dev/null 2>&1; then`,
+    `# squeezr auto-heal: start proxy if not running (validates identity, not just HTTP 200)`,
+    `_squeezr_alive() {`,
+    `  curl -sf --max-time 2 "http://localhost:${port}/squeezr/health" 2>/dev/null | grep -q '"identity":"squeezr"'`,
+    `}`,
+    `if ! _squeezr_alive; then`,
     `  nohup ${nodeExe} ${distIndex} >> "${os.homedir()}/.squeezr/squeezr.log" 2>&1 &`,
     `  disown`,
     `fi`,
+    `unset -f _squeezr_alive`,
   ].join('\n')
   const marker = '# squeezr env vars'
 
@@ -1159,11 +1202,15 @@ function setupWSL() {
     `export NODE_EXTRA_CA_CERTS=${bundlePath}`,
     `# NOTE: HTTPS_PROXY is intentionally NOT set globally — set per-session for Codex only:`,
     `# HTTPS_PROXY=http://localhost:${mitmPort} codex`,
-    `# squeezr auto-heal: start proxy if not running`,
-    `if ! curl -sf http://localhost:${port}/squeezr/health >/dev/null 2>&1; then`,
+    `# squeezr auto-heal: start proxy if not running (validates identity, not just HTTP 200)`,
+    `_squeezr_alive() {`,
+    `  curl -sf --max-time 2 "http://localhost:${port}/squeezr/health" 2>/dev/null | grep -q '"identity":"squeezr"'`,
+    `}`,
+    `if ! _squeezr_alive; then`,
     `  nohup ${nodeExe} ${distIndex} >> "${os.homedir()}/.squeezr/squeezr.log" 2>&1 &`,
     `  disown`,
     `fi`,
+    `unset -f _squeezr_alive`,
   ].join('\n')
   const marker = '# squeezr env vars'
 

--- a/src/__tests__/probePort.test.ts
+++ b/src/__tests__/probePort.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect, afterEach } from 'vitest'
+import { createServer, type Server } from 'node:http'
+import { probePort, findFreePort } from '../probePort.js'
+
+const servers: Server[] = []
+
+function startServer(handler: (req: any, res: any) => void): Promise<number> {
+  return new Promise((resolve) => {
+    const srv = createServer(handler)
+    srv.listen(0, '127.0.0.1', () => {
+      servers.push(srv)
+      resolve((srv.address() as { port: number }).port)
+    })
+  })
+}
+
+afterEach(async () => {
+  while (servers.length) {
+    const s = servers.pop()!
+    await new Promise<void>((r) => s.close(() => r()))
+  }
+})
+
+describe('probePort', () => {
+  it('returns "free" when nothing is listening on the port', async () => {
+    // Pick a high port that is almost certainly free.
+    const port = 49000 + Math.floor(Math.random() * 1000)
+    const result = await probePort(port)
+    expect(result.kind).toBe('free')
+  })
+
+  it('returns "squeezr" when the port is owned by an instance with valid identity', async () => {
+    const port = await startServer((req, res) => {
+      if (req.url === '/squeezr/health') {
+        res.writeHead(200, { 'content-type': 'application/json' })
+        res.end(JSON.stringify({ identity: 'squeezr', status: 'ok', version: '1.22.0' }))
+      } else {
+        res.writeHead(404)
+        res.end()
+      }
+    })
+    const result = await probePort(port)
+    expect(result.kind).toBe('squeezr')
+    if (result.kind === 'squeezr') {
+      expect(result.version).toBe('1.22.0')
+    }
+  })
+
+  it('returns "foreign" when the port answers HTTP 200 but identity is missing', async () => {
+    // Simulates WordPress / Apache returning 200 on /squeezr/health (e.g. a
+    // catch-all redirect or default vhost).
+    const port = await startServer((_req, res) => {
+      res.writeHead(200, { 'content-type': 'text/html' })
+      res.end('<html><body>WordPress</body></html>')
+    })
+    const result = await probePort(port)
+    expect(result.kind).toBe('foreign')
+  })
+
+  it('returns "foreign" when the port replies with a 301 redirect', async () => {
+    // The exact failure mode that triggered the original bug — Apache redirecting
+    // /squeezr/health → /squeezr/health/ — was being mistaken for a healthy
+    // squeezr by `curl -sf`.
+    const port = await startServer((_req, res) => {
+      res.writeHead(301, { location: '/somewhere/' })
+      res.end()
+    })
+    const result = await probePort(port)
+    expect(result.kind).toBe('foreign')
+    if (result.kind === 'foreign') {
+      expect(result.description).toMatch(/301/)
+    }
+  })
+
+  it('returns "foreign" when the port replies with HTTP 200 but identity != squeezr', async () => {
+    const port = await startServer((req, res) => {
+      if (req.url === '/squeezr/health') {
+        res.writeHead(200, { 'content-type': 'application/json' })
+        res.end(JSON.stringify({ identity: 'something-else', status: 'ok' }))
+      } else {
+        res.writeHead(404)
+        res.end()
+      }
+    })
+    const result = await probePort(port)
+    expect(result.kind).toBe('foreign')
+  })
+})
+
+describe('findFreePort', () => {
+  it('returns the configured port when it is free', async () => {
+    // Bind a server to occupy a known port, then ask for the next port range.
+    const occupied = await startServer((_req, res) => { res.writeHead(200); res.end() })
+    const free = await findFreePort(occupied + 1, 5)
+    expect(free).toBeGreaterThanOrEqual(occupied + 1)
+    expect(free).toBeLessThan(occupied + 6)
+  })
+
+  it('skips occupied ports and finds the next free one', async () => {
+    const occupied = await startServer((_req, res) => { res.writeHead(200); res.end() })
+    const free = await findFreePort(occupied, 5)
+    // Should NOT return the occupied port.
+    expect(free).not.toBe(occupied)
+  })
+})

--- a/src/__tests__/selfTest.test.ts
+++ b/src/__tests__/selfTest.test.ts
@@ -1,0 +1,151 @@
+import { describe, it, expect, afterEach, beforeEach } from 'vitest'
+import { createServer, type Server } from 'node:http'
+import { runSelfTest, formatSelfTest } from '../selfTest.js'
+import { VERSION } from '../version.js'
+
+const servers: Server[] = []
+
+function startSqueezrLike(opts: {
+  identity?: string
+  version?: string
+  dryRunOk?: boolean
+} = {}): Promise<number> {
+  const identity = opts.identity ?? 'squeezr'
+  const version = opts.version ?? VERSION
+  const dryRunOk = opts.dryRunOk ?? true
+
+  return new Promise((resolve) => {
+    const srv = createServer((req, res) => {
+      if (req.url === '/squeezr/health') {
+        res.writeHead(200, { 'content-type': 'application/json' })
+        res.end(JSON.stringify({ identity, status: 'ok', version }))
+        return
+      }
+      if (req.url === '/v1/messages' && req.method === 'POST') {
+        let body = ''
+        req.on('data', (c) => { body += c })
+        req.on('end', () => {
+          if (req.headers['x-squeezr-dryrun'] !== '1') {
+            res.writeHead(400); res.end('not dry-run')
+            return
+          }
+          if (!dryRunOk) {
+            res.writeHead(500); res.end('forced failure')
+            return
+          }
+          res.writeHead(200, { 'content-type': 'application/json' })
+          res.end(JSON.stringify({
+            identity: 'squeezr',
+            dry_run: true,
+            original_chars: body.length,
+            compressed_chars: body.length,
+            saved_chars: 0,
+          }))
+        })
+        return
+      }
+      res.writeHead(404); res.end()
+    })
+    srv.listen(0, '127.0.0.1', () => {
+      servers.push(srv)
+      resolve((srv.address() as { port: number }).port)
+    })
+  })
+}
+
+beforeEach(() => {
+  // Clear env vars that affect the env_coherence check; individual tests opt-in.
+  delete process.env.ANTHROPIC_BASE_URL
+  delete process.env.openai_base_url
+  delete process.env.GEMINI_API_BASE_URL
+})
+
+afterEach(async () => {
+  while (servers.length) {
+    const s = servers.pop()!
+    await new Promise<void>((r) => s.close(() => r()))
+  }
+})
+
+describe('runSelfTest', () => {
+  it('passes all checks against a healthy squeezr-like server with matching env vars', async () => {
+    const port = await startSqueezrLike()
+    process.env.ANTHROPIC_BASE_URL = `http://localhost:${port}`
+    process.env.openai_base_url = `http://localhost:${port}`
+    process.env.GEMINI_API_BASE_URL = `http://localhost:${port}`
+
+    const result = await runSelfTest({ port, offline: true })
+    const byName = Object.fromEntries(result.checks.map(c => [c.name, c]))
+    expect(byName.loopback_health.status).toBe('pass')
+    expect(byName.env_coherence.status).toBe('pass')
+    expect(byName.upstream_reachable.status).toBe('skip')
+    expect(byName.pipeline_dryrun.status).toBe('pass')
+    expect(result.status).toBe('ok')
+  })
+
+  it('marks env_coherence as warn when env vars point to the wrong port', async () => {
+    const port = await startSqueezrLike()
+    process.env.ANTHROPIC_BASE_URL = 'http://localhost:9999' // wrong on purpose
+    process.env.openai_base_url = `http://localhost:${port}`
+    process.env.GEMINI_API_BASE_URL = `http://localhost:${port}`
+
+    const result = await runSelfTest({ port, offline: true })
+    const env = result.checks.find(c => c.name === 'env_coherence')!
+    expect(env.status).toBe('warn')
+    expect(env.hint).toContain(`http://localhost:${port}`)
+    expect(result.status).toBe('warn')
+  })
+
+  it('marks loopback_health as fail when identity is missing (foreign service squatting)', async () => {
+    const port = await startSqueezrLike({ identity: 'wordpress' })
+    process.env.ANTHROPIC_BASE_URL = `http://localhost:${port}`
+    process.env.openai_base_url = `http://localhost:${port}`
+    process.env.GEMINI_API_BASE_URL = `http://localhost:${port}`
+
+    const result = await runSelfTest({ port, offline: true })
+    const health = result.checks.find(c => c.name === 'loopback_health')!
+    expect(health.status).toBe('fail')
+    expect(result.status).toBe('fail')
+  })
+
+  it('marks loopback_health as warn when version drifts', async () => {
+    const port = await startSqueezrLike({ version: '0.0.1-stale' })
+    process.env.ANTHROPIC_BASE_URL = `http://localhost:${port}`
+    process.env.openai_base_url = `http://localhost:${port}`
+    process.env.GEMINI_API_BASE_URL = `http://localhost:${port}`
+
+    const result = await runSelfTest({ port, offline: true })
+    const health = result.checks.find(c => c.name === 'loopback_health')!
+    expect(health.status).toBe('warn')
+  })
+
+  it('marks pipeline_dryrun as fail when the request path is broken', async () => {
+    const port = await startSqueezrLike({ dryRunOk: false })
+    process.env.ANTHROPIC_BASE_URL = `http://localhost:${port}`
+    process.env.openai_base_url = `http://localhost:${port}`
+    process.env.GEMINI_API_BASE_URL = `http://localhost:${port}`
+
+    const result = await runSelfTest({ port, offline: true })
+    const pipe = result.checks.find(c => c.name === 'pipeline_dryrun')!
+    expect(pipe.status).toBe('fail')
+  })
+})
+
+describe('formatSelfTest', () => {
+  it('renders pass / warn / fail icons and hints', () => {
+    const out = formatSelfTest({
+      status: 'warn',
+      port: 8080,
+      version: '1.22.0',
+      ranAt: '2026-04-14T00:00:00Z',
+      checks: [
+        { name: 'loopback_health', status: 'pass', message: 'OK' },
+        { name: 'env_coherence', status: 'warn', message: 'mismatched', hint: 'export ANTHROPIC_BASE_URL=...' },
+      ],
+    })
+    expect(out).toContain('warnings')
+    expect(out).toContain('✓ loopback_health')
+    expect(out).toContain('⚠ env_coherence')
+    expect(out).toContain('export ANTHROPIC_BASE_URL=')
+  })
+})

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,12 +1,14 @@
 import { createAdaptorServer } from '@hono/node-server'
-import { createServer } from 'node:net'
-import { app, stats } from './server.js'
+import { app, stats, setLastSelfTest } from './server.js'
 import { config } from './config.js'
 import { VERSION } from './version.js'
 import { startMitmProxy } from './codexMitm.js'
 import { loadSessionCache, persistSessionCache } from './sessionCache.js'
 import { loadExpandStore, persistExpandStore } from './expand.js'
 import { loadHistory, persistHistory } from './history.js'
+import { probePort, findFreePort } from './probePort.js'
+import { runSelfTest, formatSelfTest } from './selfTest.js'
+import { writeRuntimeInfo, clearRuntimeInfo } from './runtimeInfo.js'
 
 // Load persisted caches before accepting requests
 loadSessionCache()
@@ -15,26 +17,31 @@ loadHistory()
 
 // ── Port conflict detection ───────────────────────────────────────────────────
 // Instead of crashing with EADDRINUSE, find the next available port automatically.
+// Crucially, before drifting we identify *what* is occupying the configured port
+// — a stale squeezr instance is fine to coexist with, but a foreign HTTP service
+// (e.g. a Docker container squatting on 8080) is the source of cryptic errors
+// like `undefined is not an object (evaluating '$.speed')` in Claude Code, so
+// we surface it loudly.
 
-function isPortFree(port: number): Promise<boolean> {
-  return new Promise((resolve) => {
-    const srv = createServer()
-    srv.once('error', () => resolve(false))
-    srv.once('listening', () => srv.close(() => resolve(true)))
-    srv.listen(port)
-  })
+const initialState = await probePort(config.port)
+if (initialState.kind === 'squeezr') {
+  console.error(
+    `Squeezr v${initialState.version ?? '?'} is already running on port ${config.port}. ` +
+    `Use \`squeezr stop\` first if you want to restart.`,
+  )
+  process.exit(0)
 }
-
-async function findFreePort(start: number, max = 10): Promise<number> {
-  for (let i = 0; i < max; i++) {
-    if (await isPortFree(start + i)) return start + i
-  }
-  throw new Error(`No free port found in range ${start}–${start + max - 1}`)
+if (initialState.kind === 'foreign') {
+  console.warn(
+    `\n⚠️  Port ${config.port} is occupied by a foreign service (${initialState.description ?? 'unknown'}).\n` +
+    `   Squeezr will pick a different port, but your shell env vars likely still point to ${config.port}.\n` +
+    `   Run \`squeezr setup\` after startup to refresh them, or stop the offending service.\n`,
+  )
 }
 
 const PORT = await findFreePort(config.port)
 if (PORT !== config.port) {
-  console.warn(`\n⚠️  Port ${config.port} is already in use. Using port ${PORT} instead.`)
+  console.warn(`\n⚠️  Port ${config.port} is in use. Squeezr will listen on ${PORT} instead.`)
   console.warn(`   Update squeezr.toml or run: squeezr ports\n`)
 }
 
@@ -49,6 +56,28 @@ httpServer.listen(PORT, () => {
   if (config.disabled) console.log('WARNING: compression is disabled')
   console.log(`Backends: Anthropic → Haiku | OpenAI → GPT-4o-mini | Gemini → Flash-8B | Local → ${config.localCompressionModel}`)
   console.log(`Dashboard: http://localhost:${PORT}/squeezr/dashboard`)
+
+  // Persist runtime info so external tools (shell wrapper, auto-heal) can
+  // discover where we actually ended up bound, regardless of squeezr.toml.
+  const mitmPort = Number(process.env.SQUEEZR_MITM_PORT) || (PORT + 1)
+  writeRuntimeInfo({ pid: process.pid, port: PORT, mitmPort })
+
+  // Run self-test asynchronously — never block accepting requests on it. The
+  // test exercises loopback health, env-var coherence, upstream reachability
+  // and the full compression pipeline (dry-run, no quota cost).
+  void runSelfTest({ port: PORT }).then((result) => {
+    setLastSelfTest(result)
+    const formatted = formatSelfTest(result)
+    if (result.status === 'fail') {
+      console.error('\n' + formatted + '\n')
+    } else if (result.status === 'warn') {
+      console.warn('\n' + formatted + '\n')
+    } else {
+      console.log('\n' + formatted + '\n')
+    }
+  }).catch((err: Error) => {
+    console.error(`[squeezr] self-test crashed: ${err.message}`)
+  })
 })
 
 // Start MITM proxy for Codex OAuth (chatgpt.com/backend-api)
@@ -60,6 +89,7 @@ function persistAndExit(code = 0): void {
   persistSessionCache()
   persistExpandStore()
   persistHistory()
+  clearRuntimeInfo()
   process.exit(code)
 }
 

--- a/src/probePort.ts
+++ b/src/probePort.ts
@@ -1,0 +1,79 @@
+import { createServer } from 'node:net'
+import { request as httpRequest } from 'node:http'
+
+export type PortState =
+  | { kind: 'free' }
+  | { kind: 'squeezr'; version?: string }
+  | { kind: 'foreign'; description?: string }
+
+const HEALTH_PATH = '/squeezr/health'
+const PROBE_TIMEOUT_MS = 1500
+
+function tryBind(port: number): Promise<boolean> {
+  return new Promise((resolve) => {
+    const srv = createServer()
+    srv.once('error', () => resolve(false))
+    srv.once('listening', () => srv.close(() => resolve(true)))
+    srv.listen(port)
+  })
+}
+
+function fetchHealth(port: number): Promise<{ ok: boolean; body: string; status: number }> {
+  return new Promise((resolve) => {
+    const req = httpRequest(
+      { host: '127.0.0.1', port, path: HEALTH_PATH, method: 'GET', timeout: PROBE_TIMEOUT_MS },
+      (res) => {
+        let data = ''
+        res.on('data', (chunk) => { data += chunk })
+        res.on('end', () => resolve({ ok: true, body: data, status: res.statusCode ?? 0 }))
+      },
+    )
+    req.on('error', () => resolve({ ok: false, body: '', status: 0 }))
+    req.on('timeout', () => { req.destroy(); resolve({ ok: false, body: '', status: 0 }) })
+    req.end()
+  })
+}
+
+/**
+ * Determines whether a port is free, occupied by an existing squeezr instance,
+ * or occupied by an unrelated foreign service.
+ *
+ * The 'foreign' branch matters because Node's findFreePort + a hardcoded env
+ * var pointing to the foreign port is exactly the bug class that produces
+ * cryptic Claude Code errors like `undefined is not an object (evaluating '$.speed')`
+ * — Claude routes its API calls into a Docker WordPress (or whatever else owns
+ * the port) and chokes on the unexpected response shape.
+ */
+export async function probePort(port: number): Promise<PortState> {
+  const free = await tryBind(port)
+  if (free) return { kind: 'free' }
+
+  // Port is bound by something. Ask it whether it's squeezr.
+  const res = await fetchHealth(port)
+  if (res.ok && res.status === 200) {
+    try {
+      const json = JSON.parse(res.body) as { identity?: string; version?: string }
+      if (json && json.identity === 'squeezr') {
+        return { kind: 'squeezr', version: json.version }
+      }
+      return { kind: 'foreign', description: `HTTP 200 but identity != squeezr (got ${json.identity ?? 'undefined'})` }
+    } catch {
+      return { kind: 'foreign', description: `HTTP 200 but body is not valid JSON (${res.body.slice(0, 60)}…)` }
+    }
+  }
+  if (res.status >= 300 && res.status < 400) {
+    return { kind: 'foreign', description: `HTTP ${res.status} redirect — likely a web server (Apache/nginx/WordPress)` }
+  }
+  if (res.status >= 400) {
+    return { kind: 'foreign', description: `HTTP ${res.status}` }
+  }
+  return { kind: 'foreign', description: 'TCP bind failed but no HTTP response — non-HTTP service' }
+}
+
+export async function findFreePort(start: number, max = 10): Promise<number> {
+  for (let i = 0; i < max; i++) {
+    const state = await probePort(start + i)
+    if (state.kind === 'free') return start + i
+  }
+  throw new Error(`No free port found in range ${start}–${start + max - 1}`)
+}

--- a/src/runtimeInfo.ts
+++ b/src/runtimeInfo.ts
@@ -1,0 +1,40 @@
+import { writeFileSync, mkdirSync, unlinkSync } from 'node:fs'
+import { homedir } from 'node:os'
+import { join } from 'node:path'
+import { VERSION } from './version.js'
+
+/**
+ * Writes the actual runtime port to ~/.squeezr/runtime.json so external tools
+ * (shell wrappers, auto-heal scripts, other CLIs) can discover where squeezr
+ * is currently bound — even when findFreePort drifted away from the configured
+ * port. This is the file that lets the bash wrapper resync env vars on every
+ * new shell.
+ */
+
+export const RUNTIME_FILE = join(homedir(), '.squeezr', 'runtime.json')
+
+export interface RuntimeInfo {
+  pid: number
+  port: number
+  mitmPort: number
+  version: string
+  startedAt: string
+}
+
+export function writeRuntimeInfo(info: Omit<RuntimeInfo, 'version' | 'startedAt'>): void {
+  try {
+    mkdirSync(join(homedir(), '.squeezr'), { recursive: true })
+    const payload: RuntimeInfo = {
+      ...info,
+      version: VERSION,
+      startedAt: new Date().toISOString(),
+    }
+    writeFileSync(RUNTIME_FILE, JSON.stringify(payload, null, 2))
+  } catch {
+    // Non-fatal: runtime info is convenience, not correctness.
+  }
+}
+
+export function clearRuntimeInfo(): void {
+  try { unlinkSync(RUNTIME_FILE) } catch {}
+}

--- a/src/selfTest.ts
+++ b/src/selfTest.ts
@@ -1,0 +1,265 @@
+import { request as httpRequest } from 'node:http'
+import { connect as tlsConnect } from 'node:tls'
+import { VERSION } from './version.js'
+
+export type CheckStatus = 'pass' | 'warn' | 'fail' | 'skip'
+
+export interface SelfTestCheck {
+  name: string
+  status: CheckStatus
+  message: string
+  hint?: string
+}
+
+export interface SelfTestResult {
+  status: 'ok' | 'warn' | 'fail'
+  port: number
+  version: string
+  checks: SelfTestCheck[]
+  ranAt: string
+}
+
+interface RunOptions {
+  port: number
+  /** When true, skip checks that require network egress (DNS / TLS to upstream). */
+  offline?: boolean
+}
+
+const HEALTH_TIMEOUT_MS = 2000
+const DRYRUN_TIMEOUT_MS = 5000
+const TLS_TIMEOUT_MS = 3000
+
+const ANTHROPIC_HOST = 'api.anthropic.com'
+
+function httpJson(
+  port: number,
+  path: string,
+  init: { method?: string; headers?: Record<string, string>; body?: string; timeoutMs?: number } = {},
+): Promise<{ status: number; body: string }> {
+  return new Promise((resolve, reject) => {
+    const req = httpRequest(
+      {
+        host: '127.0.0.1',
+        port,
+        path,
+        method: init.method ?? 'GET',
+        headers: init.headers,
+        timeout: init.timeoutMs ?? HEALTH_TIMEOUT_MS,
+      },
+      (res) => {
+        let data = ''
+        res.on('data', (c) => { data += c })
+        res.on('end', () => resolve({ status: res.statusCode ?? 0, body: data }))
+      },
+    )
+    req.on('error', reject)
+    req.on('timeout', () => { req.destroy(new Error('timeout')) })
+    if (init.body) req.write(init.body)
+    req.end()
+  })
+}
+
+// ── Check A: loopback health ────────────────────────────────────────────────
+async function checkLoopbackHealth(port: number): Promise<SelfTestCheck> {
+  try {
+    const res = await httpJson(port, '/squeezr/health')
+    if (res.status !== 200) {
+      return {
+        name: 'loopback_health',
+        status: 'fail',
+        message: `Health endpoint returned HTTP ${res.status}`,
+        hint: 'Something is bound to this port but it is not squeezr. Check `lsof -i :' + port + '`.',
+      }
+    }
+    const json = JSON.parse(res.body) as { identity?: string; version?: string }
+    if (json.identity !== 'squeezr') {
+      return {
+        name: 'loopback_health',
+        status: 'fail',
+        message: `Health endpoint replied 200 but identity != "squeezr" (got ${JSON.stringify(json.identity)})`,
+        hint: 'Another HTTP service is squatting on this port. Stop it or change squeezr.toml port.',
+      }
+    }
+    if (json.version !== VERSION) {
+      return {
+        name: 'loopback_health',
+        status: 'warn',
+        message: `Stale squeezr instance: running v${json.version}, expected v${VERSION}`,
+        hint: 'Run `squeezr stop && squeezr start` to refresh.',
+      }
+    }
+    return { name: 'loopback_health', status: 'pass', message: `OK (v${VERSION})` }
+  } catch (err) {
+    return {
+      name: 'loopback_health',
+      status: 'fail',
+      message: `Could not reach loopback health endpoint: ${(err as Error).message}`,
+    }
+  }
+}
+
+// ── Check B: env var coherence ──────────────────────────────────────────────
+const ENV_KEYS = ['ANTHROPIC_BASE_URL', 'openai_base_url', 'GEMINI_API_BASE_URL'] as const
+
+function checkEnvCoherence(port: number): SelfTestCheck {
+  const expected = `http://localhost:${port}`
+  const expectedAlt = `http://127.0.0.1:${port}`
+  const mismatched: Array<{ key: string; value: string }> = []
+  const missing: string[] = []
+  for (const key of ENV_KEYS) {
+    const value = process.env[key]
+    if (!value) { missing.push(key); continue }
+    const trimmed = value.replace(/\/+$/, '')
+    if (trimmed !== expected && trimmed !== expectedAlt) {
+      mismatched.push({ key, value })
+    }
+  }
+  if (mismatched.length === 0 && missing.length === 0) {
+    return { name: 'env_coherence', status: 'pass', message: `All env vars point to ${expected}` }
+  }
+  if (mismatched.length > 0) {
+    const lines = mismatched.map(m => `  - ${m.key}=${m.value}  (expected ${expected})`).join('\n')
+    return {
+      name: 'env_coherence',
+      status: 'warn',
+      message: `Env vars do not match the bound port:\n${lines}`,
+      hint: `Update your shell profile and reopen the terminal:\n${ENV_KEYS.map(k => `  export ${k}=${expected}`).join('\n')}`,
+    }
+  }
+  return {
+    name: 'env_coherence',
+    status: 'warn',
+    message: `Some clients have no base URL set: ${missing.join(', ')}`,
+    hint: `Run \`squeezr setup\` or add to your shell profile:\n${missing.map(k => `  export ${k}=${expected}`).join('\n')}`,
+  }
+}
+
+// ── Check C: upstream reachability (DNS + TLS handshake, no payload) ────────
+function checkUpstreamReachable(): Promise<SelfTestCheck> {
+  return new Promise((resolve) => {
+    const socket = tlsConnect(
+      { host: ANTHROPIC_HOST, port: 443, servername: ANTHROPIC_HOST, timeout: TLS_TIMEOUT_MS },
+      () => {
+        socket.end()
+        resolve({ name: 'upstream_reachable', status: 'pass', message: `TLS handshake to ${ANTHROPIC_HOST} OK` })
+      },
+    )
+    socket.on('error', (err) => {
+      resolve({
+        name: 'upstream_reachable',
+        status: 'warn',
+        message: `Cannot reach ${ANTHROPIC_HOST}: ${err.message}`,
+        hint: 'Check your network / proxy / firewall. Squeezr will still start but cannot proxy requests until upstream is reachable.',
+      })
+    })
+    socket.on('timeout', () => {
+      socket.destroy()
+      resolve({
+        name: 'upstream_reachable',
+        status: 'warn',
+        message: `TLS handshake to ${ANTHROPIC_HOST} timed out after ${TLS_TIMEOUT_MS}ms`,
+      })
+    })
+  })
+}
+
+// ── Check D: compression pipeline dry-run ───────────────────────────────────
+async function checkPipelineDryRun(port: number): Promise<SelfTestCheck> {
+  // Minimal Anthropic-format payload. The dry-run header makes the server
+  // exercise compression but skip the upstream forward, so this consumes zero
+  // API quota and works without an API key.
+  const payload = JSON.stringify({
+    model: 'claude-haiku-4-5-20251001',
+    max_tokens: 16,
+    messages: [
+      {
+        role: 'user',
+        content: [{ type: 'text', text: 'self-test ping' }],
+      },
+    ],
+  })
+  try {
+    const res = await httpJson(port, '/v1/messages', {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        'x-squeezr-dryrun': '1',
+        'x-api-key': 'self-test-no-key',
+      },
+      body: payload,
+      timeoutMs: DRYRUN_TIMEOUT_MS,
+    })
+    if (res.status !== 200) {
+      return {
+        name: 'pipeline_dryrun',
+        status: 'fail',
+        message: `Dry-run pipeline returned HTTP ${res.status}: ${res.body.slice(0, 120)}`,
+      }
+    }
+    const json = JSON.parse(res.body) as { identity?: string; dry_run?: boolean }
+    if (json.identity !== 'squeezr' || json.dry_run !== true) {
+      return {
+        name: 'pipeline_dryrun',
+        status: 'fail',
+        message: `Dry-run pipeline returned unexpected payload: ${res.body.slice(0, 120)}`,
+      }
+    }
+    return { name: 'pipeline_dryrun', status: 'pass', message: 'Compression pipeline reachable end-to-end' }
+  } catch (err) {
+    return {
+      name: 'pipeline_dryrun',
+      status: 'fail',
+      message: `Dry-run pipeline failed: ${(err as Error).message}`,
+    }
+  }
+}
+
+export async function runSelfTest(opts: RunOptions): Promise<SelfTestResult> {
+  const port = opts.port
+  const checks: SelfTestCheck[] = []
+
+  checks.push(await checkLoopbackHealth(port))
+  checks.push(checkEnvCoherence(port))
+  if (opts.offline) {
+    checks.push({ name: 'upstream_reachable', status: 'skip', message: 'skipped (offline mode)' })
+  } else {
+    checks.push(await checkUpstreamReachable())
+  }
+  checks.push(await checkPipelineDryRun(port))
+
+  const hasFail = checks.some(c => c.status === 'fail')
+  const hasWarn = checks.some(c => c.status === 'warn')
+  const status: SelfTestResult['status'] = hasFail ? 'fail' : hasWarn ? 'warn' : 'ok'
+
+  return {
+    status,
+    port,
+    version: VERSION,
+    checks,
+    ranAt: new Date().toISOString(),
+  }
+}
+
+const ICONS: Record<CheckStatus, string> = {
+  pass: '✓',
+  warn: '⚠',
+  fail: '✗',
+  skip: '·',
+}
+
+export function formatSelfTest(result: SelfTestResult): string {
+  const header =
+    result.status === 'ok' ? '✓ Self-test passed' :
+    result.status === 'warn' ? '⚠ Self-test passed with warnings' :
+    '✗ Self-test FAILED'
+  const lines = [header, '']
+  for (const c of result.checks) {
+    lines.push(`  ${ICONS[c.status]} ${c.name}: ${c.message}`)
+    if (c.hint && c.status !== 'pass') {
+      for (const hintLine of c.hint.split('\n')) {
+        lines.push(`      ${hintLine}`)
+      }
+    }
+  }
+  return lines.join('\n')
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -202,6 +202,23 @@ app.post('/v1/messages', async (c) => {
   const messages = (body.messages ?? []) as unknown[]
   const originalChars = estimateChars(messages)
 
+  // Dry-run mode: exercises the compression pipeline but does NOT forward to
+  // upstream. Used by the post-start self-test to verify the request path is
+  // wired correctly without consuming any API quota.
+  if (c.req.header('x-squeezr-dryrun') === '1') {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const [dryMessages, savings] = await compressAnthropicMessages(messages as any, apiKey, config)
+    const compressedChars = estimateChars(dryMessages as unknown[])
+    return c.json({
+      identity: 'squeezr',
+      dry_run: true,
+      original_chars: originalChars,
+      compressed_chars: compressedChars,
+      saved_chars: Math.max(0, originalChars - compressedChars),
+      savings,
+    })
+  }
+
   // Bypass mode: skip all compression, still record request stats
   if (isBypassed()) {
     stats.recordWithProject(project, originalChars, originalChars, emptySavings())
@@ -600,6 +617,10 @@ app.get('/squeezr/health', (c) => {
   const cb = circuitBreaker.snapshot()
   const s = stats.summary()
   return c.json({
+    // Magic identifier so callers can distinguish a real squeezr instance from
+    // any other HTTP service that happens to answer 200 on this port (e.g. a
+    // Docker container occupying the configured port).
+    identity: 'squeezr',
     status: 'ok',
     version: VERSION,
     uptime_seconds: s.uptime_seconds,
@@ -622,6 +643,27 @@ app.get('/squeezr/health', (c) => {
       savings_pct: s.savings_pct,
     },
   })
+})
+
+// ── Self-test endpoint ─────────────────────────────────────────────────────
+// Last self-test results are populated by src/selfTest.ts at startup and on
+// demand via GET /squeezr/selftest?run=1.
+
+let lastSelfTest: unknown = null
+export function setLastSelfTest(result: unknown): void {
+  lastSelfTest = result
+}
+
+app.get('/squeezr/selftest', async (c) => {
+  if (c.req.query('run') === '1') {
+    const { runSelfTest } = await import('./selfTest.js')
+    const result = await runSelfTest({ port: Number(c.req.query('port')) || 0 })
+    return c.json(result)
+  }
+  if (!lastSelfTest) {
+    return c.json({ status: 'not_run', message: 'Self-test has not been executed yet. Call ?run=1 to execute.' })
+  }
+  return c.json(lastSelfTest)
 })
 
 // ── Project management ─────────────────────────────────────────────────────


### PR DESCRIPTION
Closes #2.

## Problem

When the configured port is occupied by an unrelated HTTP service (e.g. a Docker WordPress container squatting on `8080`), Squeezr currently:

1. Detects the collision via `findFreePort` and silently drifts to the next free port.
2. Leaves the shell env vars (`ANTHROPIC_BASE_URL`, …) pointing at the *configured* port, where the foreign service answers.
3. The auto-heal block uses `curl -sf .../squeezr/health`, which does not fail on 3xx — a WordPress 301 is mistaken for a healthy Squeezr.
4. Claude Code routes its API requests into the foreign service, which returns HTML/redirects, and crashes parsing the response with `undefined is not an object (evaluating '$.speed')`.

Full root-cause analysis in #2.

## Solution

Five additive changes, no breaking changes:

### 1. `src/probePort.ts` (new)
`probePort(port)` returns `{ kind: 'free' | 'squeezr' | 'foreign' }`, distinguishing an existing Squeezr instance (validated via the magic `identity` field on `/squeezr/health`) from an unrelated HTTP service. `findFreePort` reuses this. `src/index.ts` now logs an explicit warning when the configured port is owned by a foreign service before drifting.

### 2. `src/server.ts` — health endpoint identity + dry-run header
`GET /squeezr/health` now returns `"identity": "squeezr"` so callers can distinguish a real instance from any other 200. The `/v1/messages` handler now honors `X-Squeezr-DryRun: 1`: it runs the compression pipeline and returns `{identity, dry_run, original_chars, compressed_chars, saved_chars, savings}` without forwarding to upstream — used by the self-test to exercise the full request path with zero quota cost.

### 3. `src/selfTest.ts` (new) — four async checks
- `loopback_health` — bound port answers `/squeezr/health` with `identity === 'squeezr'` and `version === VERSION`.
- `env_coherence` — `ANTHROPIC_BASE_URL` / `openai_base_url` / `GEMINI_API_BASE_URL` actually point to the bound port. If not, prints the exact `export` lines to fix it.
- `upstream_reachable` — DNS + TLS handshake to `api.anthropic.com` (no payload, no quota cost). Marked `warn` (non-fatal) on failure.
- `pipeline_dryrun` — POSTs a minimal Anthropic request with `X-Squeezr-DryRun: 1` to verify the full request path is wired correctly.

Results: stored in memory, exposed at `GET /squeezr/selftest` (re-runnable with `?run=1`), and printed at startup. Self-test runs **after** `httpServer.listen()` and never blocks accepting requests.

### 4. `src/runtimeInfo.ts` (new)
Writes `~/.squeezr/runtime.json` with `{pid, port, mitmPort, version, startedAt}` on startup, deletes it on shutdown. The shell wrapper and `squeezr status` read this file so they always know the *actual* bound port, even when `findFreePort` drifted.

### 5. `bin/squeezr.js` — auto-heal & detection fixes
- `_squeezr_alive()` shell helper replaces `curl -sf` in `setupUnix`, `setupWSL`, and `squeezr ports`. Validates `\"identity\":\"squeezr\"` in the body via `grep -q`. A foreign 301 no longer counts as healthy.
- `startDaemon()` uses the new `probeSqueezr()` JS helper (same identity check), so it no longer enters the "version mismatch → restart" loop against a foreign service.
- `checkStatus()` reports the foreign service explicitly (with its `Server` header) instead of saying "Squeezr is NOT running".
- `getPort()` and `getMitmPort()` now prefer `~/.squeezr/runtime.json` over the toml, so the CLI always points to the live instance.

## Tests

Two new test files:

- `src/__tests__/probePort.test.ts` — 7 tests covering free / squeezr / foreign-200 / foreign-301 / wrong-identity, plus `findFreePort` skip behavior.
- `src/__tests__/selfTest.test.ts` — 6 tests covering all-pass, env mismatch warn, foreign squatter fail, version drift warn, broken dry-run pipeline fail, and `formatSelfTest` rendering.

```
Test Files  1 failed | 8 passed (9)
     Tests  7 failed | 225 passed (232)
```

The 7 failures in `compressor.test.ts` are **pre-existing on master** (verified by running `npm test` against master before any of my changes) and are not touched by this PR.

## Manual E2E verification

**Case 1 — clean start on a free port:**

```
$ SQUEEZR_PORT=8095 node dist/index.js
Squeezr v1.22.0 listening on http://localhost:8095
…
✓ loopback_health: OK (v1.22.0)
⚠ env_coherence: Some clients have no base URL set: ANTHROPIC_BASE_URL, openai_base_url, GEMINI_API_BASE_URL
    export ANTHROPIC_BASE_URL=http://localhost:8095
    …
✓ upstream_reachable: TLS handshake to api.anthropic.com OK
✓ pipeline_dryrun: Compression pipeline reachable end-to-end
```

**Case 2 — foreign service squatting on the configured port (the original bug):**

```
$ # fake WordPress on 8097 returning 301
$ SQUEEZR_PORT=8097 node dist/index.js

⚠️  Port 8097 is occupied by a foreign service (HTTP 301 redirect — likely a web server (Apache/nginx/WordPress)).
   Squeezr will pick a different port, but your shell env vars likely still point to 8097.
   Run `squeezr setup` after startup to refresh them, or stop the offending service.

⚠️  Port 8097 is in use. Squeezr will listen on 8098 instead.
Squeezr v1.22.0 listening on http://localhost:8098
…
✓ loopback_health: OK (v1.22.0)
⚠ env_coherence: …
✓ upstream_reachable: TLS handshake to api.anthropic.com OK
✓ pipeline_dryrun: Compression pipeline reachable end-to-end
```

The exact failure mode that produced `$.speed` errors is now reported clearly at startup with an actionable hint.

## Out of scope (deliberately, to keep this PR atomic)

- The MITM port (Codex, default `port + 1`) follows the same drift pattern but its own conflict detection deserves a separate PR.
- The Windows / PowerShell auto-heal — same fix conceptually, but I have no Windows machine to test it on.
- Refactoring `bin/squeezr.js` (1600 lines, would benefit from being split, but unrelated).

## Test plan
- [x] `npm run build` passes
- [x] `npm test` passes (excluding the 7 pre-existing `compressor.test.ts` failures)
- [x] E2E manual: clean start
- [x] E2E manual: start with foreign service squatting on the configured port
- [ ] Reviewer to verify: the `_squeezr_alive` shell helper works with both `bash` and `zsh` on macOS (I could only test on Linux/bash)