### PR TITLE
fix: atomic lock for shell auto-heal to prevent duplicate proxy spawns

### DIFF
--- a/bin/squeezr.js
+++ b/bin/squeezr.js
@@ -699,6 +699,68 @@ async function mcpUninstall() {
   else console.log()
 }
 
+// ── shared auto-heal block (setupUnix / setupWSL / configurePorts) ─────────────
+
+// Matches the auto-heal block from its `# squeezr env vars` marker through to
+// its final `unset -f` line, whatever function names that line unsets — so it
+// matches both the current lock-guarded block and any older pre-lock block
+// shape, and a future rename of the functions below doesn't also need a
+// matching regex update.
+const SHELL_BLOCK_REGEX = /# squeezr env vars[\s\S]*?\nunset -f [^\n]*\n?/
+
+// Builds the mkdir-locked "start the proxy if it's not already running" bash
+// snippet shared by setupUnix(), setupWSL(), and configurePorts(). Opening
+// several terminals at once can race: all of them see the proxy down before
+// any has bound the port, and all try to spawn it. Guard with an atomic lock
+// (mkdir is atomic on POSIX filesystems) so only the shell that wins the
+// mkdir spawns the process; a shell that loses the race just skips — no
+// retry, no wait — because the winner is about to make it moot.
+//
+// Pass { nodeExe, distIndex } to spawn the daemon directly (setupUnix/
+// setupWSL, which already have those paths in hand and want to avoid a
+// second CLI invocation); omit them (configurePorts) to shell out to
+// `squeezr start` instead.
+function buildAutoHealBlock(port, { nodeExe, distIndex } = {}) {
+  const spawnLines = nodeExe
+    ? [`nohup ${nodeExe} ${distIndex} >> "${os.homedir()}/.squeezr/squeezr.log" 2>&1 &`, `disown`]
+    : [`squeezr start > /dev/null 2>&1`]
+  return [
+    `_squeezr_start_if_needed() {`,
+    `  _squeezr_alive() {`,
+    `    curl -sf --max-time 2 "http://localhost:${port}/squeezr/health" 2>/dev/null | grep -q '"identity":"squeezr"'`,
+    `  }`,
+    `  _squeezr_alive && return`,
+    `  local lock="$HOME/.squeezr/.start.lock"`,
+    `  if [ -d "$lock" ]; then`,
+    `    local mtime=$(stat -f %m "$lock" 2>/dev/null || stat -c %Y "$lock" 2>/dev/null || echo 0)`,
+    `    local age=$(( $(date +%s) - mtime ))`,
+    `    [ "$age" -gt 10 ] && rmdir "$lock" 2>/dev/null   # stale lock (previous shell crashed)`,
+    `  fi`,
+    `  if mkdir "$lock" 2>/dev/null; then`,
+    `    if _squeezr_alive; then`,
+    `      rmdir "$lock" 2>/dev/null`,
+    `    else`,
+    ...spawnLines.map(l => `      ${l}`),
+    `      # Release the lock once the port is bound (or a bounded number of`,
+    `      # polls pass) in a detached background job, instead of blocking`,
+    `      # this shell's startup on it — a shell that loses the mkdir race`,
+    `      # above still finds a live proxy once this finishes, instead of`,
+    `      # also deciding it needs to spawn one.`,
+    `      ( local i max_polls=10`,
+    `        for i in $(seq 1 $max_polls); do`,
+    `          sleep 0.3`,
+    `          _squeezr_alive && break`,
+    `        done`,
+    `        rmdir "$lock" 2>/dev/null ) &`,
+    `      disown`,
+    `    fi`,
+    `  fi`,
+    `}`,
+    `_squeezr_start_if_needed`,
+    `unset -f _squeezr_start_if_needed _squeezr_alive`,
+  ].join('\n')
+}
+
 // ── squeezr ports ─────────────────────────────────────────────────────────────
 
 async function configurePorts() {
@@ -775,15 +837,16 @@ async function configurePorts() {
       `export ANTHROPIC_BASE_URL=http://localhost:${finalPort}`,
       `export GEMINI_API_BASE_URL=http://localhost:${finalPort}`,
     ].join('\n')
+    const autoHealBlock = [
+      `# squeezr auto-heal (validates identity, not just HTTP 200)`,
+      buildAutoHealBlock(finalPort),
+    ].join('\n')
     for (const p of profiles) {
       try {
         let content = fs.readFileSync(p, 'utf-8')
         if (content.includes('# squeezr env vars')) {
-          // Replace existing block (from marker to the closing fi)
-          content = content.replace(
-            /# squeezr env vars[\s\S]*?(?:fi|unset -f _squeezr_alive)/,
-            `# squeezr env vars\n${envBlock}\n# squeezr auto-heal (validates identity, not just HTTP 200)\n_squeezr_alive() {\n  curl -sf --max-time 2 "http://localhost:${finalPort}/squeezr/health" 2>/dev/null | grep -q '"identity":"squeezr"'\n}\nif ! _squeezr_alive; then squeezr start > /dev/null 2>&1; fi\nunset -f _squeezr_alive`
-          )
+          // Replace existing block (from marker to the final unset)
+          content = content.replace(SHELL_BLOCK_REGEX, `# squeezr env vars\n${envBlock}\n${autoHealBlock}\n`)
           fs.writeFileSync(p, content)
           console.log(`  [ok] Updated ${p}`)
         }
@@ -852,7 +915,7 @@ async function uninstall() {
       try {
         const content = fs.readFileSync(p, 'utf-8')
         if (content.includes('# squeezr env vars')) {
-          const cleaned = content.replace(/\n?# squeezr env vars[\s\S]*?fi\n?/g, '\n')
+          const cleaned = content.replace(new RegExp(String.raw`\n?` + SHELL_BLOCK_REGEX.source, 'g'), '\n')
           fs.writeFileSync(p, cleaned)
           console.log(`  [ok] Cleaned ${p}`)
         }
@@ -1561,14 +1624,7 @@ async function setupUnix() {
     `# (including Claude Code) through the MITM proxy and cause 502 errors.`,
     `# For Codex, set it per-session only: HTTPS_PROXY=http://localhost:${mitmPort} codex`,
     `# squeezr auto-heal: start proxy if not running (validates identity, not just HTTP 200)`,
-    `_squeezr_alive() {`,
-    `  curl -sf --max-time 2 "http://localhost:${port}/squeezr/health" 2>/dev/null | grep -q '"identity":"squeezr"'`,
-    `}`,
-    `if ! _squeezr_alive; then`,
-    `  nohup ${nodeExe} ${distIndex} >> "${os.homedir()}/.squeezr/squeezr.log" 2>&1 &`,
-    `  disown`,
-    `fi`,
-    `unset -f _squeezr_alive`,
+    buildAutoHealBlock(port, { nodeExe, distIndex }),
   ].join('\n')
   const marker = '# squeezr env vars'
 
@@ -1608,10 +1664,7 @@ async function setupUnix() {
     fs.appendFileSync(profile, `\n${shellBlock}\n`)
     console.log(`  [ok] Env vars + auto-heal added to ${profile}`)
   } else {
-    const updatedContent = existing.replace(
-      /# squeezr env vars[\s\S]*?fi\n?/,
-      shellBlock + '\n'
-    )
+    const updatedContent = existing.replace(SHELL_BLOCK_REGEX, shellBlock + '\n')
     fs.writeFileSync(profile, updatedContent)
     console.log(`  [ok] Env vars + auto-heal updated in ${profile}`)
   }
@@ -1797,14 +1850,7 @@ async function setupWSL() {
     `# NOTE: HTTPS_PROXY is intentionally NOT set globally — set per-session for Codex only:`,
     `# HTTPS_PROXY=http://localhost:${mitmPort} codex`,
     `# squeezr auto-heal: start proxy if not running (validates identity, not just HTTP 200)`,
-    `_squeezr_alive() {`,
-    `  curl -sf --max-time 2 "http://localhost:${port}/squeezr/health" 2>/dev/null | grep -q '"identity":"squeezr"'`,
-    `}`,
-    `if ! _squeezr_alive; then`,
-    `  nohup ${nodeExe} ${distIndex} >> "${os.homedir()}/.squeezr/squeezr.log" 2>&1 &`,
-    `  disown`,
-    `fi`,
-    `unset -f _squeezr_alive`,
+    buildAutoHealBlock(port, { nodeExe, distIndex }),
   ].join('\n')
   const marker = '# squeezr env vars'
 
@@ -1842,10 +1888,7 @@ async function setupWSL() {
     fs.appendFileSync(profile, `\n${shellBlock}\n`)
     console.log(`  [ok] Env vars + auto-heal added to ${profile}`)
   } else {
-    const updatedContent = existing.replace(
-      /# squeezr env vars[\s\S]*?fi\n?/,
-      shellBlock + '\n'
-    )
+    const updatedContent = existing.replace(SHELL_BLOCK_REGEX, shellBlock + '\n')
     fs.writeFileSync(profile, updatedContent)
     console.log(`  [ok] Env vars + auto-heal updated in ${profile}`)
   }


### PR DESCRIPTION
Fixes #6.

## Problem

The `.bashrc`/`.zshrc` auto-heal block that `squeezr setup` writes (run on every new interactive shell) checked whether the proxy was alive and spawned it if not, with no locking. Opening several terminals close together let multiple shells run `_squeezr_alive` before any process had bound the port, so all of them spawned a `dist/index.js` daemon — leading to orphaned processes, `No free port found in range 8080–8089`, and (per the report) a 176MB log file from repeated restarts. Because `squeezr setup`/`update`/a port change regenerate this block unconditionally, any local patch to it also got silently overwritten.

## Fix

Wrap the check-and-spawn in an `mkdir`-based atomic lock (`mkdir` is atomic on POSIX filesystems), as suggested in the issue:

- Stale-lock cleanup (~10s) in case a shell crashed mid-block and left the lock dir behind.
- Re-check `_squeezr_alive` once the lock is held, since another shell may have started the proxy between the first check and acquiring the lock.
- Hold the lock until the proxy is confirmed alive or ~3s pass, polling every 0.3s after spawning — otherwise a shell that lost the `mkdir` race could still spawn a second daemon in the gap before the winner's process finishes binding the port (the winner's `nohup ... &` returns immediately; it doesn't wait for the port itself).
- Applied to all three places that generate this block: `setupUnix`, `setupWSL`, and the port-change auto-heal regen in `configurePorts`.
- Widened the update/uninstall regexes (previously anchored on the first `fi`) to match through to the block's final `unset -f`, and to accept both the new and the pre-lock block shape — so upgrading from an older install replaces the whole block cleanly instead of leaving orphaned lines, and `squeezr uninstall` fully removes either shape from `.bashrc`/`.zshrc`.

## Verification

`npm test` — 553 passed / 4 skipped, no failures.

Since this touches generated shell code in a plain-JS CLI script (no existing test harness for `bin/squeezr.js`), I verified behavior by extracting the exact block `setupUnix` generates and sourcing it from concurrent shells:

- **20 concurrent shells, proxy down** (real generated block + a fake `dist/index.js` that sleeps ~700ms before binding, simulating Node startup): exactly 1 process spawned and bound the port, confirmed via `pgrep` and a live health check. Before this fix the same setup spawns once per shell.
- **Stale lock** (lock dir mtime backdated 30s): cleaned up and the proxy started.
- **Live lock** (freshly created, not stale): the shell backed off without spawning, as expected.
- **Already-alive fast path**: no lock touched, no spawn, when a healthy proxy already answers.
- **Update/uninstall regexes**: confirmed against both the old (single `if/fi`) and new (nested `if/fi`) block text — update replaces the block wholesale with no leftover lines, uninstall removes it cleanly, and re-running setup on an already-new block is idempotent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
